### PR TITLE
Fixes unicode buffer interface error.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-scrypt
+scrypt==0.6.1
+Werkzeug==0.9.6


### PR DESCRIPTION
Current safe_str_cmp function may produce unicode buffer interface error on some versions of python, replacing with safe_str_cmp() from Werkzeug library.